### PR TITLE
Clear underlying PSR-16 cache also

### DIFF
--- a/src/Psr6/CachePool.php
+++ b/src/Psr6/CachePool.php
@@ -166,6 +166,7 @@ class CachePool implements CacheItemPoolInterface
      */
     public function clear()
     {
+        $this->_cacheEngine->clear();
         $this->bufferKeys = [];
         $this->buffer = [];
     }


### PR DESCRIPTION
The PSR-6 adapter, `ByJG\Cache\Psr6\CachePool` was not clearing the underlying PSR-16 `ByJG\Cache\Psr16\*CacheEngine`. Fixed it.